### PR TITLE
Add correct id for Lampeudtag dimmer

### DIFF
--- a/custom_components/light/ihc.py
+++ b/custom_components/light/ihc.py
@@ -25,7 +25,7 @@ PRODUCTAUTOSETUP = [
     {'xpath': './/product_airlink[@product_identifier="_0x4406"]',
      'node': 'airlink_dimming'},
     #Wireless Lampeudtag dimmer
-    {'xpath': './/product_airlink[@product_identifier="_0x4306"]',
+    {'xpath': './/product_airlink[@product_identifier="_0x4304"]',
      'node': 'airlink_dimming'},
     #Wireless Lampeudtag relay
     {'xpath': './/product_airlink[@product_identifier="_0x4202"]',


### PR DESCRIPTION
The previous id 4306 is a universal dimmer, not a Lampeudtag dimmer